### PR TITLE
Fix: 400 error when creating room

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -8,7 +8,6 @@ export const fetch_start_agent = async (
       "Content-Type": "application/json",
       "Authorization": `Bearer ${serverAuth}`
     },
-    body: JSON.stringify({}),
   });
 
   const data = await req.json();


### PR DESCRIPTION
When attempting to create a room, cerebrium responds with a 400 (Bad request error). This happens because it is not expecting an empty body.